### PR TITLE
Android: binder: implement sched_policy, rt_priority

### DIFF
--- a/include/uapi/linux/android/binder.h
+++ b/include/uapi/linux/android/binder.h
@@ -193,6 +193,7 @@ struct binder_version {
 #define BINDER_SET_CONTEXT_MGR		_IOW('b', 7, __s32)
 #define BINDER_THREAD_EXIT		_IOW('b', 8, __s32)
 #define BINDER_VERSION			_IOWR('b', 9, struct binder_version)
+#define BINDER_SET_INHERIT_FIFO_PRIO	_IO('b', 10)
 
 /*
  * NOTE: Two special error codes you should check for when calling


### PR DESCRIPTION
Add system calls support to set the scheduling policy & priority for
real-time scheduling policy.

rt_priority is a field specifies the priority to be applied
by real-time scheduling policies.

Associated attributes for the thread whose ID is specified in pid.
If pid equals zero, the policy and attributes of the
calling thread will be set.
The main reasons a PI rt_mutex does not work well are the following:
1) Binder supports asynchronous transactions, where a caller is not blocked
   on a result; therefore, the caller also could not block on a rt_mutex.
2) Binder supports the concept of node priority, where the priority of a
   call is not determined by the caller, but by the endpoint the caller
   calls in to.
3) There may not necessarily be any binder threads waiting to handle a
   transaction, so the caller does not always have a thread to change the
   priority of; instead, the first thread to pick up the work changes its
   own priority.
4) rt_mutex does not support non-RT policies (though a patch was sent to
   LKML once to address this).