### PR TITLE
Memory management: add min free order shift tunable

### DIFF
--- a/include/linux/mm.h
+++ b/include/linux/mm.h
@@ -1926,6 +1926,7 @@ extern void zone_pcp_reset(struct zone *zone);
 /* page_alloc.c */
 extern int min_free_kbytes;
 extern int extra_free_kbytes;
+extern int min_free_order_shift;
 extern int watermark_scale_factor;
 
 /* nommu.c */

--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -1516,6 +1516,13 @@ static struct ctl_table vm_table[] = {
 		.extra1		= &zero,
 	},
 	{
+		.procname	= "min_free_order_shift",
+		.data		= &min_free_order_shift,
+		.maxlen		= sizeof(min_free_order_shift),
+		.mode		= 0644,
+		.proc_handler	= proc_dointvec,
+	},
+	{
 		.procname	= "watermark_scale_factor",
 		.data		= &watermark_scale_factor,
 		.maxlen		= sizeof(watermark_scale_factor),

--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -260,6 +260,7 @@ compound_page_dtor * const compound_page_dtors[] = {
  */
 int min_free_kbytes = 1024;
 int user_min_free_kbytes = -1;
+int min_free_order_shift = 1;
 int watermark_scale_factor = 10;
 
 /*


### PR DESCRIPTION
By default the kernel tries to keep half as much memory free at each
order as it does for one order below. This can be too agressive when
running without swap.

Patch provides dummy API to avoid console noise like:
/proc/sys/vm/min_free_order_shift: No such file or directory